### PR TITLE
Potential fix for code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -627,7 +627,13 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   // Admin logout
-  app.post("/api/admin/auth/logout", requireAdmin(), (req, res) => {
+  const logoutRateLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 50, // max 50 requests per windowMs
+    message: { success: false, error: "Too many logout attempts, please try again later." }
+  });
+
+  app.post("/api/admin/auth/logout", requireAdmin(), logoutRateLimiter, (req, res) => {
     try {
       const admin = req.admin;
       if (admin.sessionId) {


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/Network_Identity-NXD/security/code-scanning/4](https://github.com/CreoDAMO/Network_Identity-NXD/security/code-scanning/4)

To address the issue, a rate-limiting middleware should be added to the `/api/admin/auth/logout` route. The `express-rate-limit` package is already imported in the file, so we can define a new rate limiter specifically for this route. The rate limiter will restrict the number of logout requests that can be made within a specified time window. This ensures that the route is protected against abuse while maintaining its functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
